### PR TITLE
setup: add support for the --enable-data-download flag

### DIFF
--- a/attributes/defaults.rb
+++ b/attributes/defaults.rb
@@ -1,3 +1,4 @@
 default[:libpostal][:codedir] = "/usr/local/libpostal"
 default[:libpostal][:datadir] = "/usr/local/libpostal-data/"
 default[:libpostal][:revision] = 'master'
+default[:libpostal][:disable_data_download] = 'no'

--- a/attributes/defaults.rb
+++ b/attributes/defaults.rb
@@ -1,4 +1,4 @@
 default[:libpostal][:codedir] = "/usr/local/libpostal"
 default[:libpostal][:datadir] = "/usr/local/libpostal-data/"
 default[:libpostal][:revision] = 'master'
-default[:libpostal][:disable_data_download] = 'no'
+default[:libpostal][:enable_data_download] = 'yes'

--- a/templates/default/setup-libpostal.erb
+++ b/templates/default/setup-libpostal.erb
@@ -10,7 +10,7 @@ cd <%= node[:libpostal][:codedir] %>
 git checkout <%= node[:libpostal][:revision] %>
 
 ./bootstrap.sh
-./configure --datadir=<%= node[:libpostal][:datadir] %> --disable-data-download=<%= node[:libpostal][:disable_data_download] %>
+./configure --datadir=<%= node[:libpostal][:datadir] %> --enable_data_download=<%= node[:libpostal][:enable_data_download] %>
 make install
 ldconfig
 

--- a/templates/default/setup-libpostal.erb
+++ b/templates/default/setup-libpostal.erb
@@ -10,7 +10,7 @@ cd <%= node[:libpostal][:codedir] %>
 git checkout <%= node[:libpostal][:revision] %>
 
 ./bootstrap.sh
-./configure --datadir=<%= node[:libpostal][:datadir] %> --enable_data_download=<%= node[:libpostal][:enable_data_download] %>
+./configure --datadir=<%= node[:libpostal][:datadir] %> --enable-data-download=<%= node[:libpostal][:enable_data_download] %>
 make install
 ldconfig
 

--- a/templates/default/setup-libpostal.erb
+++ b/templates/default/setup-libpostal.erb
@@ -10,7 +10,7 @@ cd <%= node[:libpostal][:codedir] %>
 git checkout <%= node[:libpostal][:revision] %>
 
 ./bootstrap.sh
-./configure --datadir=<%= node[:libpostal][:datadir] %>
+./configure --datadir=<%= node[:libpostal][:datadir] %> --disable-data-download=<%= node[:libpostal][:disable_data_download] %>
 make install
 ldconfig
 


### PR DESCRIPTION
this PR adds support for the `--enable-data-download` flag, which allows more flexibility when building AMI images, as the data download and lib install processes can be separated.